### PR TITLE
Chain legacy redirects and add install redirect

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -397,23 +397,27 @@
   "redirects": [
     {
       "source": "/support",
-      "destination": "/atopile-0.14.x/support"
+      "destination": "/atopile/support"
     },
     {
       "source": "/installation",
-      "destination": "/atopile-0.14.x/quickstart/1-installation"
+      "destination": "/atopile/quickstart/1-installation"
+    },
+    {
+      "source": "/atopile/guides/install",
+      "destination": "/atopile/quickstart/1-installation"
     },
     {
       "source": "/publish-package",
-      "destination": "/atopile-0.14.x/guides/publish"
+      "destination": "/atopile/guides/publish"
     },
     {
       "source": "/quickstart",
-      "destination": "/atopile-0.14.x/quickstart/1-installation"
+      "destination": "/atopile/quickstart/1-installation"
     },
     {
       "source": "/package-management",
-      "destination": "/atopile-0.14.x/essentials/4-packages"
+      "destination": "/atopile/essentials/4-packages"
     },
     {
       "source": "/atopile/:slug*",


### PR DESCRIPTION
## Summary
- Redirect destinations now use `/atopile/...` instead of hardcoded `/atopile-0.14.x/...`, so they chain through the wildcard and won't need updating when the default version changes
- Adds specific redirect for `/atopile/guides/install` → `/atopile/quickstart/1-installation` since that page was removed in 0.14.x

## Test plan
- [x] Verified locally with `mintlify dev` that old paths redirect correctly
- [x] Confirmed `/atopile/guides/install` resolves to the installation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)